### PR TITLE
Fix out of control recursive directory copy

### DIFF
--- a/spec/fs-plus-spec.coffee
+++ b/spec/fs-plus-spec.coffee
@@ -249,3 +249,16 @@ describe "fs", ->
       it "copies the file and folder", ->
         expect(fs.isFileSync(path.join(destination, 'a.txt'))).toBeTruthy()
         expect(fs.isDirectorySync(path.join(destination, 'b'))).toBeTruthy()
+
+      describe "source is copied into itself", ->
+        beforeEach ->
+          source = temp.mkdirSync('fs-plus-')
+          destination = source
+          fs.writeFileSync(path.join(source, 'a.txt'), 'a')
+          fs.makeTreeSync(path.join(source, 'b'))
+          fs.copySync(source, path.join(destination, path.basename(source)))
+
+        it "copies the directory once", ->
+          expect(fs.isDirectorySync(path.join(destination, path.basename(source)))).toBeTruthy()
+          expect(fs.isDirectorySync(path.join(destination, path.basename(source), 'b'))).toBeTruthy()
+          expect(fs.isDirectorySync(path.join(destination, path.basename(source), path.basename(source)))).toBeFalsy()

--- a/src/fs-plus.coffee
+++ b/src/fs-plus.coffee
@@ -226,8 +226,11 @@ fsPlus =
 
   # Public: Copies the given path recursively and synchronously.
   copySync: (sourcePath, destinationPath) ->
+    # We need to save the sources before creaing the new directory to avoid
+    # infinitely creating copies of the directory when copying inside itself
+    sources = fs.readdirSync(sourcePath)
     mkdirp.sync(destinationPath)
-    for source in fs.readdirSync(sourcePath)
+    for source in sources
       sourceFilePath = path.join(sourcePath, source)
       destinationFilePath = path.join(destinationPath, source)
 


### PR DESCRIPTION
This fixes an issue where if a directory is copied into itself, that it keeps recursively creating copies inside of each new copy forever until we get a filesystem error saying that the filename is too long.
