### PR TITLE
Add "compiled" python files

### DIFF
--- a/src/fs-plus.coffee
+++ b/src/fs-plus.coffee
@@ -399,10 +399,10 @@ fsPlus =
       '.DS_Store'
       '.a'
       '.o'
-      '.so'
-      '.woff'
       '.pyc'
       '.pyo'
+      '.so'
+      '.woff'
     ], ext, true) >= 0
 
   # Public: Returns true for files named similarily to 'README'


### PR DESCRIPTION
This adds python bytecode files to the binary listing.

`.pyc` is compiled python byte-code
`.pyo` is _optimized_ compiled python byte-code
