### PR TITLE
Add .war and .epub files to compressed extensions

### DIFF
--- a/src/fs-plus.coffee
+++ b/src/fs-plus.coffee
@@ -375,10 +375,12 @@ fsPlus =
   # Public: Returns true for extensions associated with compressed files.
   isCompressedExtension: (ext) ->
     _.indexOf([
+      '.epub'
       '.gz'
       '.jar'
       '.tar'
       '.tgz'
+      '.war'
       '.zip'
     ], ext, true) >= 0
 


### PR DESCRIPTION
Since node-ls-archive treat .war and .epub files as zips (atom/node-ls-archive#2), it's user-friendly to show them as archive files.
