### PR TITLE
Add detection of more .zip formats: .egg, .whl, and .xpi

### DIFF
--- a/src/fs-plus.coffee
+++ b/src/fs-plus.coffee
@@ -428,8 +428,8 @@ fsPlus =
   isCompressedExtension: (ext) ->
     _.indexOf([
       '.bz2'
-      '.epub'
       '.egg'
+      '.epub'
       '.gz'
       '.jar'
       '.lz'

--- a/src/fs-plus.coffee
+++ b/src/fs-plus.coffee
@@ -429,6 +429,7 @@ fsPlus =
     _.indexOf([
       '.bz2'
       '.epub'
+      '.egg'
       '.gz'
       '.jar'
       '.lz'
@@ -437,6 +438,8 @@ fsPlus =
       '.tar'
       '.tgz'
       '.war'
+      '.whl'
+      '.xpi'
       '.xz'
       '.z'
       '.zip'


### PR DESCRIPTION
As just added to archive-view and node-ls-archive, .egg and .whl are zipped Python packages, and .xpi is Mozilla's zipped extension format.