### PR TITLE
Use fs.stat instead of fs.exists

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "underscore-plus": "1.x",
     "mkdirp": "~0.3.5",
     "rimraf": "~2.2.2",
-    "async": "~0.2.9",
-    "is-there": "1.1.0"
+    "async": "~0.2.9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "underscore-plus": "1.x",
     "mkdirp": "~0.3.5",
     "rimraf": "~2.2.2",
-    "async": "~0.2.9"
+    "async": "~0.2.9",
+    "is-there": "1.1.0"
   }
 }

--- a/spec/fs-plus-spec.coffee
+++ b/spec/fs-plus-spec.coffee
@@ -82,11 +82,14 @@ describe "fs", ->
       fs.makeTreeSync(abcPath)
       expect(fs.isDirectorySync(abcPath)).toBeTruthy()
 
+
   describe ".makeTree(path)", ->
     aPath = path.join(temp.dir, 'a')
+    fPath = path.join(temp.openSync().path, 'f')
 
     beforeEach ->
       fs.removeSync(aPath) if fs.existsSync(aPath)
+      fs.removeSync(fPath) if fs.existsSync(fPath)
 
     it "creates all directories in path including any missing parent directories", ->
       callback = jasmine.createSpy('callback')
@@ -108,6 +111,26 @@ describe "fs", ->
       runs ->
         expect(callback.argsForCall[1][0]).toBeUndefined()
         expect(fs.isDirectorySync(abcPath)).toBeTruthy()
+
+    it "fails because the provided path is a file", ->
+      callback = jasmine.createSpy('callback')
+      fbcPath = path.join(fPath, 'b', 'c')
+      fs.makeTree(fbcPath, callback)
+
+      waitsFor ->
+        callback.callCount is 1
+
+      runs ->
+        expect(callback.argsForCall[0][0]).toBeTruthy()
+        fs.makeTree(fbcPath, callback)
+
+      waitsFor ->
+        callback.callCount is 2
+
+      runs ->
+        expect(callback.argsForCall[1][0]).toBeTruthy()
+        expect(fs.isDirectorySync(fbcPath)).toBeFalsy()
+
 
   describe ".traverseTreeSync(path, onFile, onDirectory)", ->
     it "calls fn for every path in the tree at the given path", ->

--- a/src/fs-plus.coffee
+++ b/src/fs-plus.coffee
@@ -1,7 +1,6 @@
 fs = require 'fs'
 Module = require 'module'
 path = require 'path'
-isThere = require 'is-there'
 
 _ = require 'underscore-plus'
 async = require 'async'
@@ -96,7 +95,7 @@ fsPlus =
 
   # Public: Returns true if a file or folder at the specified path exists.
   existsSync: (pathToCheck) ->
-    isPathValid(pathToCheck) and (isThere.sync(pathToCheck) isnt false)
+    isPathValid(pathToCheck) and (statSyncNoException(pathToCheck) isnt false)
 
   # Public: Returns true if the given path exists and is a directory.
   isDirectorySync: (directoryPath) ->
@@ -109,15 +108,11 @@ fsPlus =
   # Public: Asynchronously checks that the given path exists and is a directory.
   isDirectory: (directoryPath, done) ->
     return done(false) unless isPathValid(directoryPath)
-    isThere directoryPath, (exists) ->
-      if exists
-        fs.stat directoryPath, (error, stat) ->
-          if error?
-            done(false)
-          else
-            done(stat.isDirectory())
-      else
+    fs.stat directoryPath, (error, stat) ->
+      if error?
         done(false)
+      else
+        done(stat.isDirectory())
 
   # Public: Returns true if the specified path exists and is a file.
   isFileSync: (filePath) ->
@@ -288,7 +283,7 @@ fsPlus =
   # Public: Create a directory at the specified path including any missing
   # parent directories asynchronously.
   makeTree: (directoryPath, callback) ->
-    isThere directoryPath, (exists) ->
+    fsPlus.isDirectory directoryPath, (exists) ->
       return callback?() if exists
       mkdirp directoryPath, (error) -> callback?(error)
 

--- a/src/fs-plus.coffee
+++ b/src/fs-plus.coffee
@@ -278,7 +278,7 @@ fsPlus =
   # Public: Create a directory at the specified path including any missing
   # parent directories synchronously.
   makeTreeSync: (directoryPath) ->
-    mkdirp.sync(directoryPath) unless fsPlus.existsSync(directoryPath)
+    mkdirp.sync(directoryPath) unless fsPlus.isDirectorySync(directoryPath)
 
   # Public: Create a directory at the specified path including any missing
   # parent directories asynchronously.

--- a/src/fs-plus.coffee
+++ b/src/fs-plus.coffee
@@ -96,7 +96,7 @@ fsPlus =
 
   # Public: Returns true if a file or folder at the specified path exists.
   existsSync: (pathToCheck) ->
-    isPathValid(pathToCheck) and (statSyncNoException(pathToCheck) isnt false)
+    isPathValid(pathToCheck) and (isThere.sync(pathToCheck) isnt false)
 
   # Public: Returns true if the given path exists and is a directory.
   isDirectorySync: (directoryPath) ->
@@ -288,7 +288,7 @@ fsPlus =
   # Public: Create a directory at the specified path including any missing
   # parent directories asynchronously.
   makeTree: (directoryPath, callback) ->
-    fs.exists directoryPath, (exists) ->
+    isThere directoryPath, (exists) ->
       return callback?() if exists
       mkdirp directoryPath, (error) -> callback?(error)
 

--- a/src/fs-plus.coffee
+++ b/src/fs-plus.coffee
@@ -30,7 +30,7 @@ fsPlus =
   #                home directory.
   #
   # Returns the {String} absolute path or the relative path if it's unable to
-  # determine its realpath.
+  # determine its real path.
   absolute: (relativePath) ->
     return null unless relativePath?
 
@@ -46,7 +46,7 @@ fsPlus =
     catch e
       relativePath
 
-  # Public: Normalize the given path treating a leading `~` segment as refering
+  # Public: Normalize the given path treating a leading `~` segment as referring
   # to the home directory. This method does not query the filesystem.
   #
   # pathToNormalize - The {String} containing the abnormal path. If the path is
@@ -67,7 +67,7 @@ fsPlus =
 
     normalizedPath
 
-  # Public: Get path to store application specific data
+  # Public: Get path to store application specific data.
   #
   # Returns the {String} absolute path or null if platform isn't supported
   # Mac: ~/Library/Application Support/

--- a/src/fs-plus.coffee
+++ b/src/fs-plus.coffee
@@ -1,6 +1,7 @@
 fs = require 'fs'
 Module = require 'module'
 path = require 'path'
+isThere = require 'is-there'
 
 _ = require 'underscore-plus'
 async = require 'async'
@@ -108,7 +109,7 @@ fsPlus =
   # Public: Asynchronously checks that the given path exists and is a directory.
   isDirectory: (directoryPath, done) ->
     return done(false) unless isPathValid(directoryPath)
-    fs.exists directoryPath, (exists) ->
+    isThere directoryPath, (exists) ->
       if exists
         fs.stat directoryPath, (error, stat) ->
           if error?


### PR DESCRIPTION
I replaced all the `fs.exists` and `fs.existsSync` calls with `fs.stat` and `statSyncNoException`. It is an alternative to `fs.exists` and `fs.existsSync`, because [they will be deprecated](https://nodejs.org/api/fs.html#fs_fs_exists_path_callback).