### PR TITLE
Keep extensions in obj for faster access, easier maintenance

### DIFF
--- a/spec/fs-plus-spec.coffee
+++ b/spec/fs-plus-spec.coffee
@@ -639,3 +639,52 @@ describe "fs", ->
 
       expect(fs.existsSync(filePath)).toBe false
       expect(fs.existsSync(newFilePath)).toBe true
+
+
+  describe '.isBinaryExtension', ->
+
+    it 'returns true for a recognized binary file extension', ->
+      expect(fs.isBinaryExtension('.DS_Store')).toBe true
+
+    it 'returns false for non-binary file extension', ->
+      expect(fs.isBinaryExtension('.bz2')).toBe false
+
+  describe ".isCompressedExtension", ->
+
+    it 'returns true for a recognized compressed file extension', ->
+      expect(fs.isCompressedExtension('.bz2')).toBe true
+
+    it 'returns false for non-compressed file extension', ->
+      expect(fs.isCompressedExtension('.jpg')).toBe false
+
+  describe '.isImageExtension', ->
+
+    it 'returns true for a recognized image file extension', ->
+      expect(fs.isImageExtension('.jpg')).toBe true
+
+    it 'returns false for non-image file extension', ->
+      expect(fs.isImageExtension('.bz2')).toBe false
+
+  describe '.isMarkdownExtension', ->
+
+    it 'returns true for a recognized Markdown file extension', ->
+      expect(fs.isMarkdownExtension('.md')).toBe true
+
+    it 'returns false for non-Markdown file extension', ->
+      expect(fs.isMarkdownExtension('.bz2')).toBe false
+
+  describe '.isPdfExtension', ->
+
+    it 'returns true for a recognized PDF file extension', ->
+      expect(fs.isPdfExtension('.pdf')).toBe true
+
+    it 'returns false for non-PDF file extension', ->
+      expect(fs.isPdfExtension('.bz2')).toBe false
+
+  describe '.isReadmePath', ->
+
+    it 'returns true for a recognized README path', ->
+      expect(fs.isReadmePath('./path/to/README.md')).toBe true
+
+    it 'returns false for non README path', ->
+      expect(fs.isReadmePath('./path/foo.txt')).toBe false

--- a/spec/fs-plus-spec.coffee
+++ b/spec/fs-plus-spec.coffee
@@ -640,9 +640,7 @@ describe "fs", ->
       expect(fs.existsSync(filePath)).toBe false
       expect(fs.existsSync(newFilePath)).toBe true
 
-
   describe '.isBinaryExtension', ->
-
     it 'returns true for a recognized binary file extension', ->
       expect(fs.isBinaryExtension('.DS_Store')).toBe true
 
@@ -650,7 +648,6 @@ describe "fs", ->
       expect(fs.isBinaryExtension('.bz2')).toBe false
 
   describe ".isCompressedExtension", ->
-
     it 'returns true for a recognized compressed file extension', ->
       expect(fs.isCompressedExtension('.bz2')).toBe true
 
@@ -658,7 +655,6 @@ describe "fs", ->
       expect(fs.isCompressedExtension('.jpg')).toBe false
 
   describe '.isImageExtension', ->
-
     it 'returns true for a recognized image file extension', ->
       expect(fs.isImageExtension('.jpg')).toBe true
 
@@ -666,7 +662,6 @@ describe "fs", ->
       expect(fs.isImageExtension('.bz2')).toBe false
 
   describe '.isMarkdownExtension', ->
-
     it 'returns true for a recognized Markdown file extension', ->
       expect(fs.isMarkdownExtension('.md')).toBe true
 
@@ -674,7 +669,6 @@ describe "fs", ->
       expect(fs.isMarkdownExtension('.bz2')).toBe false
 
   describe '.isPdfExtension', ->
-
     it 'returns true for a recognized PDF file extension', ->
       expect(fs.isPdfExtension('.pdf')).toBe true
 
@@ -682,7 +676,6 @@ describe "fs", ->
       expect(fs.isPdfExtension('.bz2')).toBe false
 
   describe '.isReadmePath', ->
-
     it 'returns true for a recognized README path', ->
       expect(fs.isReadmePath('./path/to/README.md')).toBe true
 

--- a/src/fs-plus.coffee
+++ b/src/fs-plus.coffee
@@ -455,36 +455,11 @@ fsPlus =
 
   # Public: Returns true for extensions associated with compressed files.
   isCompressedExtension: (ext) ->
-    _.indexOf([
-      '.bz2'
-      '.egg'
-      '.epub'
-      '.gz'
-      '.jar'
-      '.lz'
-      '.lzma'
-      '.lzo'
-      '.tar'
-      '.tgz'
-      '.war'
-      '.whl'
-      '.xpi'
-      '.xz'
-      '.z'
-      '.zip'
-    ], ext, true) >= 0
+    COMPRESSED_EXTENSIONS[ext] == true
 
   # Public: Returns true for extensions associated with image files.
   isImageExtension: (ext) ->
-    _.indexOf([
-      '.gif'
-      '.ico'
-      '.jpeg'
-      '.jpg'
-      '.png'
-      '.tiff'
-      '.webp'
-    ], ext, true) >= 0
+    IMAGE_EXTENSIONS[ext] == true
 
   # Public: Returns true for extensions associated with pdf files.
   isPdfExtension: (ext) ->
@@ -492,16 +467,7 @@ fsPlus =
 
   # Public: Returns true for extensions associated with binary files.
   isBinaryExtension: (ext) ->
-    _.indexOf([
-      '.DS_Store'
-      '.a'
-      '.exe'
-      '.o'
-      '.pyc'
-      '.pyo'
-      '.so'
-      '.woff'
-    ], ext, true) >= 0
+    BINARY_EXTENSIONS[ext] == true
 
   # Public: Returns true for files named similarily to 'README'
   isReadmePath: (readmePath) ->
@@ -511,15 +477,7 @@ fsPlus =
 
   # Public: Returns true for extensions associated with Markdown files.
   isMarkdownExtension: (ext) ->
-    _.indexOf([
-      '.markdown'
-      '.md'
-      '.mdown'
-      '.mkd'
-      '.mkdown'
-      '.rmd'
-      '.ron'
-    ], ext, true) >= 0
+    MARKDOWN_EXTENSIONS[ext] == true
 
   # Public: Is the filesystem case insensitive?
   #
@@ -552,6 +510,56 @@ lstatSyncNoException ?= (args...) ->
     fs.lstatSync(args...)
   catch error
     false
+
+BINARY_EXTENSIONS = {
+  '.DS_Store': true,
+  '.a': true,
+  '.exe': true,
+  '.o': true,
+  '.pyc': true,
+  '.pyo': true,
+  '.so': true,
+  '.woff': true,
+}
+
+COMPRESSED_EXTENSIONS = {
+  '.bz2': true,
+  '.egg': true,
+  '.epub': true,
+  '.gz': true,
+  '.jar': true,
+  '.lz': true,
+  '.lzma': true,
+  '.lzo': true,
+  '.tar': true,
+  '.tgz': true,
+  '.war': true,
+  '.whl': true,
+  '.xpi': true,
+  '.xz': true,
+  '.z': true,
+  '.zip': true,
+}
+
+IMAGE_EXTENSIONS = {
+  '.gif': true,
+  '.ico': true,
+  '.jpeg': true,
+  '.jpg': true,
+  '.png': true,
+  '.tiff': true,
+  '.webp': true,
+}
+
+MARKDOWN_EXTENSIONS = {
+  '.markdown': true,
+  '.md': true,
+  '.mdown': true,
+  '.mkd': true,
+  '.mkdown': true,
+  '.rmd': true,
+  '.ron': true,
+}
 
 isPathValid = (pathToCheck) ->
   pathToCheck? and typeof pathToCheck is 'string' and pathToCheck.length > 0

--- a/src/fs-plus.coffee
+++ b/src/fs-plus.coffee
@@ -455,11 +455,11 @@ fsPlus =
 
   # Public: Returns true for extensions associated with compressed files.
   isCompressedExtension: (ext) ->
-    _.has(COMPRESSED_EXTENSIONS, ext)
+    COMPRESSED_EXTENSIONS.hasOwnProperty(ext)
 
   # Public: Returns true for extensions associated with image files.
   isImageExtension: (ext) ->
-    _.has(IMAGE_EXTENSIONS, ext)
+    IMAGE_EXTENSIONS.hasOwnProperty(ext)
 
   # Public: Returns true for extensions associated with pdf files.
   isPdfExtension: (ext) ->
@@ -467,7 +467,7 @@ fsPlus =
 
   # Public: Returns true for extensions associated with binary files.
   isBinaryExtension: (ext) ->
-    _.has(BINARY_EXTENSIONS, ext)
+    BINARY_EXTENSIONS.hasOwnProperty(ext)
 
   # Public: Returns true for files named similarily to 'README'
   isReadmePath: (readmePath) ->
@@ -477,7 +477,7 @@ fsPlus =
 
   # Public: Returns true for extensions associated with Markdown files.
   isMarkdownExtension: (ext) ->
-    _.has(MARKDOWN_EXTENSIONS, ext)
+    MARKDOWN_EXTENSIONS.hasOwnProperty(ext)
 
   # Public: Is the filesystem case insensitive?
   #

--- a/src/fs-plus.coffee
+++ b/src/fs-plus.coffee
@@ -455,11 +455,11 @@ fsPlus =
 
   # Public: Returns true for extensions associated with compressed files.
   isCompressedExtension: (ext) ->
-    COMPRESSED_EXTENSIONS[ext] == true
+    _.has(COMPRESSED_EXTENSIONS, ext)
 
   # Public: Returns true for extensions associated with image files.
   isImageExtension: (ext) ->
-    IMAGE_EXTENSIONS[ext] == true
+    _.has(IMAGE_EXTENSIONS, ext)
 
   # Public: Returns true for extensions associated with pdf files.
   isPdfExtension: (ext) ->
@@ -467,7 +467,7 @@ fsPlus =
 
   # Public: Returns true for extensions associated with binary files.
   isBinaryExtension: (ext) ->
-    BINARY_EXTENSIONS[ext] == true
+    _.has(BINARY_EXTENSIONS, ext)
 
   # Public: Returns true for files named similarily to 'README'
   isReadmePath: (readmePath) ->
@@ -477,7 +477,7 @@ fsPlus =
 
   # Public: Returns true for extensions associated with Markdown files.
   isMarkdownExtension: (ext) ->
-    MARKDOWN_EXTENSIONS[ext] == true
+    _.has(MARKDOWN_EXTENSIONS, ext)
 
   # Public: Is the filesystem case insensitive?
   #


### PR DESCRIPTION
Rather than an array, use an object to determine whether a given
extension matches the chosen type. This gives a constant look up time
rather than `O(log(n))` look up time of `indexOf`. There's no inherent order
in the extensions, so the ordering of an array is not needed.