### PR TITLE
Keep traversing when non-file/directory is encountered

### DIFF
--- a/src/fs-plus.coffee
+++ b/src/fs-plus.coffee
@@ -384,6 +384,8 @@ fsPlus =
                     callback()
               else
                 callback()
+            else
+              callback()
         queue.concurrency = 1
         queue.drain = onDone
         queue.push(path.join(rootPath, file)) for file in files


### PR DESCRIPTION
Fixes an issue I'm seeing where traverseTree will stop silently when it encounters a socket.