### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,12 +15,7 @@
     "url": "https://github.com/atom/fs-plus/issues"
   },
   "homepage": "http://atom.github.io/fs-plus",
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://github.com/atom/fs-plus/raw/master/LICENSE.md"
-    }
-  ],
+  "license": "MIT",
   "keywords": [
     "fs",
     "filesystem"


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/