### PR TITLE
Test file extensions case-insensitively

### DIFF
--- a/spec/fs-plus-spec.coffee
+++ b/spec/fs-plus-spec.coffee
@@ -646,6 +646,9 @@ describe "fs", ->
 
     it 'returns false for non-binary file extension', ->
       expect(fs.isBinaryExtension('.bz2')).toBe false
+    
+    it 'returns true for an uppercase binary file extension', ->
+      expect(fs.isBinaryExtension('.EXE')).toBe true
 
   describe ".isCompressedExtension", ->
     it 'returns true for a recognized compressed file extension', ->
@@ -667,6 +670,9 @@ describe "fs", ->
 
     it 'returns false for non-Markdown file extension', ->
       expect(fs.isMarkdownExtension('.bz2')).toBe false
+    
+    it 'returns true for a recognised Markdown file extension with unusual capitalisation', ->
+      expect(fs.isMarkdownExtension('.MaRKdOwN')).toBe true
 
   describe '.isPdfExtension', ->
     it 'returns true for a recognized PDF file extension', ->
@@ -674,6 +680,9 @@ describe "fs", ->
 
     it 'returns false for non-PDF file extension', ->
       expect(fs.isPdfExtension('.bz2')).toBe false
+    
+    it 'returns true for an uppercase PDF file extension', ->
+      expect(fs.isPdfExtension('.PDF')).toBe true
 
   describe '.isReadmePath', ->
     it 'returns true for a recognized README path', ->

--- a/src/fs-plus.coffee
+++ b/src/fs-plus.coffee
@@ -457,19 +457,22 @@ fsPlus =
 
   # Public: Returns true for extensions associated with compressed files.
   isCompressedExtension: (ext) ->
-    COMPRESSED_EXTENSIONS.hasOwnProperty(ext)
+    return false unless ext?
+    COMPRESSED_EXTENSIONS.hasOwnProperty(ext.toLowerCase())
 
   # Public: Returns true for extensions associated with image files.
   isImageExtension: (ext) ->
-    IMAGE_EXTENSIONS.hasOwnProperty(ext)
+    return false unless ext?
+    IMAGE_EXTENSIONS.hasOwnProperty(ext.toLowerCase())
 
   # Public: Returns true for extensions associated with pdf files.
   isPdfExtension: (ext) ->
-    ext is '.pdf'
+    ext?.toLowerCase() is '.pdf'
 
   # Public: Returns true for extensions associated with binary files.
   isBinaryExtension: (ext) ->
-    BINARY_EXTENSIONS.hasOwnProperty(ext)
+    return false unless ext?
+    BINARY_EXTENSIONS.hasOwnProperty(ext.toLowerCase())
 
   # Public: Returns true for files named similarily to 'README'
   isReadmePath: (readmePath) ->
@@ -479,7 +482,8 @@ fsPlus =
 
   # Public: Returns true for extensions associated with Markdown files.
   isMarkdownExtension: (ext) ->
-    MARKDOWN_EXTENSIONS.hasOwnProperty(ext)
+    return false unless ext?
+    MARKDOWN_EXTENSIONS.hasOwnProperty(ext.toLowerCase())
 
   # Public: Is the filesystem case insensitive?
   #

--- a/src/fs-plus.coffee
+++ b/src/fs-plus.coffee
@@ -518,7 +518,7 @@ lstatSyncNoException ?= (args...) ->
     false
 
 BINARY_EXTENSIONS =
-  '.DS_Store': true
+  '.ds_store': true
   '.a':        true
   '.exe':      true
   '.o':        true


### PR DESCRIPTION
I noticed a PDF file didn't have the correct icon while browsing documents:

<img width="271" alt="Figure 1" src="https://cloud.githubusercontent.com/assets/2346707/14384832/a08b1652-fde0-11e5-8af1-a4516265bea3.png">

I traced the issue to this module. It doesn't accommodate file extensions with different permutations of capitalisation.

Rather than add checks for uppercased variants, I altered the `is*Extension` methods to normalise the capitalisation before returning a result.

Even though it's unlikely a file would be saved as `.MaRkdowN`, such an abomination of Latin letters should still be interpreted by filesystems as a markdown file.