### PR TITLE
Add ".gem" to list of compressed file extensions

### DIFF
--- a/src/fs-plus.coffee
+++ b/src/fs-plus.coffee
@@ -527,6 +527,7 @@ COMPRESSED_EXTENSIONS =
   '.bz2':  true
   '.egg':  true
   '.epub': true
+  '.gem':  true
   '.gz':   true
   '.jar':  true
   '.lz':   true


### PR DESCRIPTION
Gems are basically just [gzipped folders](http://guides.rubygems.org/what-is-a-gem/) generated by RubyGems.