### PR TITLE
Add ".tif" as a recognised TIFF extension

### DIFF
--- a/src/fs-plus.coffee
+++ b/src/fs-plus.coffee
@@ -553,6 +553,7 @@ IMAGE_EXTENSIONS =
   '.jpeg': true
   '.jpg':  true
   '.png':  true
+  '.tif':  true
   '.tiff': true
   '.webp': true
 


### PR DESCRIPTION
[TIFF images](https://en.wikipedia.org/wiki/Tagged_Image_File_Format) sometimes use the `.tif` extension instead of `.tiff`, analogous to `.jpg/jpeg`.