### PR TITLE
Add traverseTree test & update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "underscore-plus": "1.x",
-    "mkdirp": "~0.3.5",
+    "mkdirp": "^0.5.1",
     "rimraf": "~2.2.2",
     "async": "~0.2.9"
   }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "underscore-plus": "1.x",
     "mkdirp": "^0.5.1",
-    "rimraf": "~2.2.2",
+    "rimraf": "^2.5.2",
     "async": "^1.5.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
     "underscore-plus": "1.x",
     "mkdirp": "^0.5.1",
     "rimraf": "~2.2.2",
-    "async": "~0.2.9"
+    "async": "^1.5.2"
   }
 }

--- a/spec/fs-plus-spec.coffee
+++ b/spec/fs-plus-spec.coffee
@@ -237,6 +237,86 @@ describe "fs", ->
       fs.traverseTreeSync(directory, onPath)
       expect(paths.length).toBe 0
 
+  describe ".traverseTree(path, onFile, onDirectory, onDone)", ->
+    it "calls fn for every path in the tree at the given path", ->
+      paths = []
+      onPath = (childPath) ->
+        paths.push(childPath)
+        true
+      done = false
+      onDone = ->
+        done = true
+      fs.traverseTree fixturesDir, onPath, onPath, onDone
+
+      waitsFor ->
+        done
+
+      runs ->
+        expect(paths).toEqual fs.listTreeSync(fixturesDir)
+
+    it "does not recurse into a directory if it is pruned", ->
+      paths = []
+      onPath = (childPath) ->
+        if childPath.match(/\/dir$/)
+          false
+        else
+          paths.push(childPath)
+          true
+      done = false
+      onDone = ->
+        done = true
+
+      fs.traverseTree fixturesDir, onPath, onPath, onDone
+
+      waitsFor ->
+        done
+
+      runs ->
+        expect(paths.length).toBeGreaterThan 0
+        for filePath in paths
+          expect(filePath).not.toMatch /\/dir\//
+
+    it "returns entries if path is a symlink", ->
+      symlinkPath = path.join(fixturesDir, 'symlink-to-dir')
+      symlinkPaths = []
+
+      onSymlinkPath = (path) -> symlinkPaths.push(path.substring(symlinkPath.length + 1))
+
+      regularPath = path.join(fixturesDir, 'dir')
+      paths = []
+      onPath = (path) -> paths.push(path.substring(regularPath.length + 1))
+
+      symlinkDone = false
+      onSymlinkPathDone = ->
+        symlinkDone = true
+
+      regularDone = false
+      onRegularPathDone = ->
+        regularDone = true
+
+      fs.traverseTree symlinkPath, onSymlinkPath, onSymlinkPath, onSymlinkPathDone
+      fs.traverseTree regularPath, onPath, onPath, onRegularPathDone
+
+      waitsFor ->
+        symlinkDone && regularDone
+
+      runs ->
+        expect(symlinkPaths).toEqual(paths)
+
+    it "ignores missing symlinks", ->
+      directory = temp.mkdirSync('symlink-in-here')
+      paths = []
+      onPath = (childPath) -> paths.push(childPath)
+      fs.symlinkSync(path.join(directory, 'source'), path.join(directory, 'destination'))
+      done = false
+      onDone = ->
+        done = true
+      fs.traverseTree directory, onPath, onPath, onDone
+      waitsFor ->
+        done
+      runs ->
+        expect(paths.length).toBe 0
+
   describe ".md5ForPath(path)", ->
     it "returns the MD5 hash of the file at the given path", ->
       expect(fs.md5ForPath(require.resolve('./fixtures/sample.js'))).toBe 'dd38087d0d7e3e4802a6d3f9b9745f2b'


### PR DESCRIPTION
Since I'm updating `async` and only `traverseTree` uses it, I thought I'd add it a test.

https://github.com/caolan/async/compare/0.2.9...v1.5.2
https://github.com/substack/node-mkdirp/compare/0.3.5...0.5.1
https://github.com/isaacs/rimraf/compare/v2.2.2...v2.5.2