### PR TITLE
Add copyFileSync(sourceFilePath, destinationFilePath)

### DIFF
--- a/spec/fs-plus-spec.coffee
+++ b/spec/fs-plus-spec.coffee
@@ -416,6 +416,14 @@ describe "fs", ->
           expect(fs.isDirectorySync(path.join(destination, path.basename(source), 'b'))).toBeTruthy()
           expect(fs.isDirectorySync(path.join(destination, path.basename(source), path.basename(source)))).toBeFalsy()
 
+  describe ".copyFileSync(sourceFilePath, destinationFilePath)", ->
+    it "copies the specified file", ->
+      sourceFilePath = temp.path()
+      destinationFilePath = temp.path()
+      fs.writeFileSync(sourceFilePath, 'ABCDE'.repeat(20000))
+      fs.copyFileSync(sourceFilePath, destinationFilePath)
+      expect(fs.readFileSync(destinationFilePath, 'utf8')).toBe(fs.readFileSync(sourceFilePath, 'utf8'))
+
   describe ".isCaseSensitive()/isCaseInsensitive()", ->
     it "does not return the same value for both", ->
       expect(fs.isCaseInsensitive()).not.toBe fs.isCaseSensitive()
@@ -646,7 +654,7 @@ describe "fs", ->
 
     it 'returns false for non-binary file extension', ->
       expect(fs.isBinaryExtension('.bz2')).toBe false
-    
+
     it 'returns true for an uppercase binary file extension', ->
       expect(fs.isBinaryExtension('.EXE')).toBe true
 
@@ -670,7 +678,7 @@ describe "fs", ->
 
     it 'returns false for non-Markdown file extension', ->
       expect(fs.isMarkdownExtension('.bz2')).toBe false
-    
+
     it 'returns true for a recognised Markdown file extension with unusual capitalisation', ->
       expect(fs.isMarkdownExtension('.MaRKdOwN')).toBe true
 
@@ -680,7 +688,7 @@ describe "fs", ->
 
     it 'returns false for non-PDF file extension', ->
       expect(fs.isPdfExtension('.bz2')).toBe false
-    
+
     it 'returns true for an uppercase PDF file extension', ->
       expect(fs.isPdfExtension('.PDF')).toBe true
 

--- a/spec/fs-plus-spec.coffee
+++ b/spec/fs-plus-spec.coffee
@@ -420,7 +420,9 @@ describe "fs", ->
     it "copies the specified file", ->
       sourceFilePath = temp.path()
       destinationFilePath = temp.path()
-      fs.writeFileSync(sourceFilePath, 'ABCDE'.repeat(20000))
+      content = ''
+      content += 'ABCDE' for i in [0...20000] by 1
+      fs.writeFileSync(sourceFilePath, content)
       fs.copyFileSync(sourceFilePath, destinationFilePath)
       expect(fs.readFileSync(destinationFilePath, 'utf8')).toBe(fs.readFileSync(sourceFilePath, 'utf8'))
 

--- a/src/fs-plus.coffee
+++ b/src/fs-plus.coffee
@@ -324,11 +324,13 @@ fsPlus =
     try
       readFd = fs.openSync(sourceFilePath, 'r')
       writeFd = fs.openSync(destinationFilePath, 'w')
-      loop
+      bytesRead = 1
+      position = 0
+      while bytesRead > 0
         buffer = new Buffer(bufferSize)
-        bytesRead = fs.readSync(readFd, buffer, 0, buffer.length)
-        fs.writeSync(writeFd, buffer, 0, bytesRead)
-        break if bytesRead < buffer.length
+        bytesRead = fs.readSync(readFd, buffer, 0, buffer.length, position)
+        fs.writeSync(writeFd, buffer, 0, bytesRead, position)
+        position += bytesRead
     finally
       fs.closeSync(readFd) if readFd?
       fs.closeSync(writeFd) if writeFd?

--- a/src/fs-plus.coffee
+++ b/src/fs-plus.coffee
@@ -309,8 +309,29 @@ fsPlus =
       if fsPlus.isDirectorySync(sourceFilePath)
         fsPlus.copySync(sourceFilePath, destinationFilePath)
       else
-        content = fs.readFileSync(sourceFilePath)
-        fs.writeFileSync(destinationFilePath, content)
+        fsPlus.copyFileSync(sourceFilePath, destinationFilePath)
+
+  # Public: Copies the given path synchronously, buffering reads and writes to
+  # keep memory footprint to a minimum.
+  #
+  # * sourceFilePath - A {String} representing the file path you want to copy.
+  # * destinationFilePath - A {String} representing the file path where the file will be copied.
+  # * bufferSize - An {Integer} representing the size in bytes of the buffer
+  #   when reading from and writing to disk. The default is 16KB.
+  copyFileSync: (sourceFilePath, destinationFilePath, bufferSize=16 * 1024) ->
+    readFd = null
+    writeFd = null
+    try
+      readFd = fs.openSync(sourceFilePath, 'r')
+      writeFd = fs.openSync(destinationFilePath, 'w')
+      loop
+        buffer = new Buffer(bufferSize)
+        bytesRead = fs.readSync(readFd, buffer, 0, buffer.length)
+        fs.writeSync(writeFd, buffer, 0, bytesRead)
+        break if bytesRead < buffer.length
+    finally
+      fs.closeSync(readFd) if readFd?
+      fs.closeSync(writeFd) if writeFd?
 
   # Public: Create a directory at the specified path including any missing
   # parent directories synchronously.


### PR DESCRIPTION
This method implements a synchronous method to copy a file from a location to another (you can think of it as a synchronous version of `fs.createReadStream().pipe(fs.createWriteStream())`). It will be used in atom/atom#11828 to prevent the main process (on which the file recovery service runs) from having huge spikes in memory when backing up large files.

By default, the buffer size will be 16KB, which seems to be a reasonable tradeoff between memory usage and speed (based on http://codecapsule.com/2014/02/12/coding-for-ssds-part-6-a-summary-what-every-programmer-should-know-about-solid-state-drives/ that's the size of a page in most SSDs, and should be good for hard disks too), but callers can customize this parameter as well.

/cc: @atom/core