### PR TITLE
Add function to tildify path

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,17 @@ home directory. This method does not query the filesystem.
 #### Return
  - **String** Returns a normalized path.
 
+### `tildify(pathToTildify)`
+Convert an absolute path to tilde path for linux and mac:
+/Users/username/dev => ~/dev
+
+#### Params
+
+ - **String** `pathToTildify`: The string containing the full path.
+
+#### Return
+ - **String** Returns a tildified path.
+
 ### `getAppDataDirectory()`
 Get path to store application specific data.
 

--- a/package.json
+++ b/package.json
@@ -30,9 +30,10 @@
     "temp": "~0.8.1"
   },
   "dependencies": {
-    "underscore-plus": "1.x",
+    "async": "~0.2.9",
     "mkdirp": "~0.3.5",
     "rimraf": "~2.2.2",
-    "async": "~0.2.9"
+    "tildify": "^1.2.0",
+    "underscore-plus": "1.x"
   }
 }

--- a/spec/fs-plus-spec.coffee
+++ b/spec/fs-plus-spec.coffee
@@ -502,6 +502,21 @@ describe "fs", ->
       expect(fs.normalize('~')).toBe fs.getHomeDirectory()
       expect(fs.normalize('~/foo')).toBe path.join(fs.getHomeDirectory(), 'foo')
 
+  describe ".tildify(pathToTildify)", ->
+    it "tildifys the path", ->
+      home = fs.getHomeDirectory()
+      if process.platform is 'win32'
+        expect(fs.tildify(home)).toBe home
+      else
+        expect(fs.tildify(home)).toBe '~'
+        expect(fs.tildify(path.join(home, 'foo'))).toBe '~/foo'
+        fixture = path.join('foo', fs.getHomeDirectory())
+        expect(fs.tildify(fixture)).toBe fixture
+        fixture = path.resolve("#{home}foo", 'tildify')
+        expect(fs.tildify(fixture)).toBe fixture
+        expect(fs.tildify('foo')).toBe 'foo'
+
+
   describe ".move", ->
     tempDir = null
 

--- a/src/fs-plus.coffee
+++ b/src/fs-plus.coffee
@@ -4,6 +4,7 @@ path = require 'path'
 
 _ = require 'underscore-plus'
 async = require 'async'
+tildify = require 'tildify'
 mkdirp = require 'mkdirp'
 rimraf = require 'rimraf'
 
@@ -68,9 +69,7 @@ fsPlus =
   # Returns a tildified path {String}.
   tildify: (pathToTildify) ->
     return pathToTildify if process.platform is 'win32'
-    home = fsPlus.getHomeDirectory()
-    str = path.normalize(pathToTildify.toString()) + path.sep
-    return (if str.indexOf(home) is 0 then str.replace(home + path.sep, '~' + path.sep) else str).slice(0, -1)
+    return tildify(pathToTildify)
 
   # Public: Get path to store application specific data.
   #

--- a/src/fs-plus.coffee
+++ b/src/fs-plus.coffee
@@ -60,6 +60,12 @@ fsPlus =
       return "#{fsPlus.getHomeDirectory()}#{relativePath.substring(1)}"
     return relativePath
 
+  # Public: Convert an absolute path to tilde path for linux and mac:
+  # /Users/username/dev => ~/dev
+  #
+  # pathToTildify - The {String} containing the full path.
+  #
+  # Returns a tildified path {String}.
   tildify: (pathToTildify) ->
     return pathToTildify if process.platform is 'win32'
     home = fsPlus.getHomeDirectory()

--- a/src/fs-plus.coffee
+++ b/src/fs-plus.coffee
@@ -60,6 +60,12 @@ fsPlus =
       return "#{fsPlus.getHomeDirectory()}#{relativePath.substring(1)}"
     return relativePath
 
+  tildify: (pathToTildify) ->
+    return pathToTildify if process.platform is 'win32'
+    home = fsPlus.getHomeDirectory()
+    str = path.normalize(pathToTildify.toString()) + path.sep
+    return (if str.indexOf(home) is 0 then str.replace(home + path.sep, '~' + path.sep) else str).slice(0, -1)
+
   # Public: Get path to store application specific data.
   #
   # Returns the {String} absolute path or null if platform isn't supported


### PR DESCRIPTION
Convert an absolute path to tilde path for linux and mac: `/Users/username/dev` -> `~/dev`

This would be used in https://github.com/atom/atom/pull/12573