### PR TITLE
Update mkdirp dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "async": "~0.2.9",
-    "mkdirp": "~0.3.5",
+    "mkdirp": "^0.5.1",
     "rimraf": "~2.2.2",
     "tildify": "^1.2.0",
     "underscore-plus": "1.x"


### PR DESCRIPTION
The old `mkdirp` version is not compatible with strict mode as mentioned in https://github.com/substack/node-mkdirp/issues/98 a while ago.

If you guys are not going to merge #29 you can at least merge this one.
I can submit more PRs or extend this one with other dependency updates. 