### PR TITLE
Missing callback argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Returns `true` if a file or folder at the specified path exists.
 ### `isDirectorySync(directoryPath)`
 Returns `true` if the given path exists and is a directory.
 
-### `isDirectory(directoryPath)`
+### `isDirectory(directoryPath, callback)`
 Asynchronously checks that the given path exists and is a directory.
 
 ### `isFileSync(filePath)`


### PR DESCRIPTION
The callback argument for `isDirectory` was missing in the README.