### PR TITLE
Enable snapshot

### DIFF
--- a/src/fs-plus.coffee
+++ b/src/fs-plus.coffee
@@ -652,4 +652,7 @@ isMoveTargetValidSync = (source, target) ->
 module.exports = new Proxy({}, {
   get: (target, key) ->
     fsPlus[key] ? fs[key]
+
+  set: (target, key, value) ->
+    fsPlus[key] = value
 })

--- a/src/fs-plus.coffee
+++ b/src/fs-plus.coffee
@@ -473,11 +473,14 @@ fsPlus =
   # Public: Like {.resolve} but uses node's modules paths as the load paths to
   # search.
   resolveOnLoadPath: (args...) ->
-    modulePaths = module.paths ? [
-      path.join(process.resourcesPath, 'app', 'node_modules'),
-      path.join(process.resourcesPath, 'app.asar', 'node_modules'),
-      path.join(process.resourcesPath, 'node_modules')
-    ]
+    modulePaths = null
+    if module.paths?
+      modulePaths = module.paths
+    else if process.resourcesPath
+      modulePaths = [path.join(process.resourcesPath, 'app', 'node_modules')]
+    else
+      modulePaths = []
+
     loadPaths = Module.globalPaths.concat(modulePaths)
     fsPlus.resolve(loadPaths..., args...)
 


### PR DESCRIPTION
This pull request changes fs-plus so that it can be required while generating a v8 snapshot. It does so by: 

1. Using a `Proxy` object instead of creating a new object containing both fs-plus and fs methods. The nice thing about this approach is that it doesn't break the API which, as a result, allows us to not change the callers of `fs-plus` in Atom.
2. Changing `resolveOnLoadPath` to use `module.paths` only if present. In the case of a snapshot we won't be able to provide the absolute resolution paths at require-time (i.e. they depend on the location where Atom is installed at and the snapshot is generated on a CI server), but we can still resolve them by using `snapshotResult.entryPointDirPath`.

The downside of `Proxy` objects is that they're ~2x slower, so if you repeatedly call `fs-plus` functions there's a chance performance will regress. On the other hand, when dealing with the file system what's usually slow is I/O and therefore the overhead of proxies might be negligible.