### PR TITLE
fix: support node 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ notifications:
 
 node_js:
   - 6
+  - 4
 
 git:
   depth: 10


### PR DESCRIPTION
this is direct dep of highlights and highlights supports node 4. your recent release (2.10.0) breaks on node 4. you aren't checking on travis, which is probably how you didn't know. this adds a check for node 4 to your travis.yml.