### PR TITLE
Revert "Revert "Enable snapshot""

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ notifications:
     on_failure: change
 
 node_js:
+  - 7
   - 6
-  - 4
 
 git:
   depth: 10

--- a/src/fs-plus.coffee
+++ b/src/fs-plus.coffee
@@ -15,6 +15,8 @@ rimraf = require 'rimraf'
 #
 # [fs]: http://nodejs.org/api/fs.html
 fsPlus =
+  __esModule: false
+
   getHomeDirectory: ->
     if process.platform is 'win32'
       process.env.USERPROFILE
@@ -471,7 +473,15 @@ fsPlus =
   # Public: Like {.resolve} but uses node's modules paths as the load paths to
   # search.
   resolveOnLoadPath: (args...) ->
-    loadPaths = Module.globalPaths.concat(module.paths)
+    modulePaths = null
+    if module.paths?
+      modulePaths = module.paths
+    else if process.resourcesPath
+      modulePaths = [path.join(process.resourcesPath, 'app', 'node_modules')]
+    else
+      modulePaths = []
+
+    loadPaths = Module.globalPaths.concat(modulePaths)
     fsPlus.resolve(loadPaths..., args...)
 
   # Public: Finds the first file in the given path which matches the extension
@@ -541,18 +551,23 @@ fsPlus =
   # Returns `true` if case sensitive, `false` otherwise.
   isCaseSensitive: -> not fsPlus.isCaseInsensitive()
 
-{statSyncNoException, lstatSyncNoException} = fs
-statSyncNoException ?= (args...) ->
-  try
-    fs.statSync(args...)
-  catch error
-    false
+statSyncNoException = (args...) ->
+  if fs.statSyncNoException
+    fs.statSyncNoException(args...)
+  else
+    try
+      fs.statSync(args...)
+    catch error
+      false
 
-lstatSyncNoException ?= (args...) ->
-  try
-    fs.lstatSync(args...)
-  catch error
-    false
+lstatSyncNoException = (args...) ->
+  if fs.lstatSyncNoException
+    fs.lstatSyncNoException(args...)
+  else
+    try
+      fs.lstatSync(args...)
+    catch error
+      false
 
 BINARY_EXTENSIONS =
   '.ds_store': true
@@ -603,8 +618,6 @@ MARKDOWN_EXTENSIONS =
   '.rmd':      true
   '.ron':      true
 
-
-
 isPathValid = (pathToCheck) ->
   pathToCheck? and typeof pathToCheck is 'string' and pathToCheck.length > 0
 
@@ -639,4 +652,10 @@ isMoveTargetValidSync = (source, target) ->
     oldStat.dev is newStat.dev and
     oldStat.ino is newStat.ino
 
-module.exports = _.extend({}, fs, fsPlus)
+module.exports = new Proxy({}, {
+  get: (target, key) ->
+    fsPlus[key] ? fs[key]
+
+  set: (target, key, value) ->
+    fsPlus[key] = value
+})


### PR DESCRIPTION
Reverts atom/fs-plus#40. This time we will bump the major version to prevent breakage for modules depending on fs-plus that need to work on Node 4 or earlier.