### PR TITLE
Do not tildify paths if HOME is not set

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ home directory. This method does not query the filesystem.
  - **String** Returns a normalized path.
 
 ### `tildify(pathToTildify)`
-Convert an absolute path to tilde path for linux and mac:
+Convert an absolute path to tilde path on Linux and macOS:
 /Users/username/dev => ~/dev
 
 #### Params
@@ -67,8 +67,8 @@ Get path to store application specific data.
 #### Return
  - **String** Returns the absolute path or null if platform isn't supported
 
-    - Mac: `~/Library/Application Support/`
-    - Win: `%AppData%`
+    - macOS: `~/Library/Application Support/`
+    - Windows: `%AppData%`
     - Linux: `/var/lib`
 
 ### `isAbsolute(pathToCheck)`

--- a/spec/fs-plus-spec.coffee
+++ b/spec/fs-plus-spec.coffee
@@ -663,6 +663,14 @@ describe "fs", ->
       expect(fs.normalize('~/foo')).toBe path.join(fs.getHomeDirectory(), 'foo')
 
   describe ".tildify(pathToTildify)", ->
+    getHomeDirectory = null
+
+    beforeEach ->
+      getHomeDirectory = fs.getHomeDirectory
+
+    afterEach ->
+      fs.getHomeDirectory = getHomeDirectory
+
     it "tildifys the path on Linux and macOS", ->
       return if process.platform is 'win32'
 
@@ -675,6 +683,15 @@ describe "fs", ->
       fixture = path.resolve("#{home}foo", 'tildify')
       expect(fs.tildify(fixture)).toBe fixture
       expect(fs.tildify('foo')).toBe 'foo'
+
+    it "does not tildify if home is unset", ->
+      return if process.platform is 'win32'
+
+      home = fs.getHomeDirectory()
+      fs.getHomeDirectory = -> return undefined
+
+      fixture = path.join(home, 'foo')
+      expect(fs.tildify(fixture)).toBe fixture
 
     it "doesn't change URLs or paths not tildified", ->
       urlToLeaveAlone = "https://atom.io/something/fun?abc"

--- a/src/fs-plus.coffee
+++ b/src/fs-plus.coffee
@@ -73,6 +73,7 @@ fsPlus =
 
     normalized = fsPlus.normalize(pathToTildify)
     homeDir = fsPlus.getHomeDirectory()
+    return pathToTildify unless homeDir?
 
     return '~' if normalized is homeDir
     return pathToTildify unless normalized.startsWith(path.join(homeDir, path.sep))


### PR DESCRIPTION
Avoids the issue reported in https://github.com/atom/status-bar/issues/184 although why HOME is unset is still a mystery.