### PR TITLE
Use generic HOME environment variable for Windows if set

### DIFF
--- a/src/fs-plus.coffee
+++ b/src/fs-plus.coffee
@@ -18,7 +18,7 @@ fsPlus =
   __esModule: false
 
   getHomeDirectory: ->
-    if process.platform is 'win32'
+    if process.platform is 'win32' and not process.env.HOME
       process.env.USERPROFILE
     else
       process.env.HOME


### PR DESCRIPTION
Normally, `USERPROFILE` is only the one environment variable which Windows applications use to determine home directory. A lot of tools support `HOME` and cross-common environment variable (git, etc.). Even [Python interpreter checks](https://docs.python.org/2/library/os.path.html#os.path.expanduser) for HOME before USERPROFILE.

We have a few reported issues related to this problem. Our tool is written in Python but we have PlatformIO IDE extensions for Atom/VSCode. As result, `getHomeDirectory` differs from Python's `os.path.expanduser`.

Sure, we can implement own `getHomeDirectory` in our Node.JS helper tools but I think this PR could be useful for other developers who use a common HOME environment variable.