### PR TITLE
Don't use deprecated [l]statSyncNoException methods in Electron >= 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,3 +233,11 @@ Returns `true` if case insensitive, `false` otherwise.
 ### `isCaseSensitive()`
 Is the filesystem case sensitive?
 Returns `true` if case sensitive, `false` otherwise.
+
+### `statSyncNoException(path[, options])`
+Calls [`fs.statSync`](https://nodejs.org/docs/latest-v10.x/api/fs.html#fs_fs_statsync_path_options), catching all exceptions raised. This method calls `fs.statSyncNoException` when provided by the underlying `fs` module (Electron < 3.0).
+Returns `fs.Stats` if the file exists, `undefined` otherwise.
+
+### `lstatSyncNoException(path[, options])`
+Calls [`fs.lstatSync`](https://nodejs.org/docs/latest-v10.x/api/fs.html#fs_fs_lstatsync_path_options), catching all exceptions raised. This method calls `fs.lstatSyncNoException` when provided by the underlying `fs` module (Electron < 3.0).
+Returns `fs.Stats` if the file exists, `undefined` otherwise.

--- a/src/fs-plus.coffee
+++ b/src/fs-plus.coffee
@@ -552,8 +552,30 @@ fsPlus =
   # Returns `true` if case sensitive, `false` otherwise.
   isCaseSensitive: -> not fsPlus.isCaseInsensitive()
 
+  # Public: Calls `fs.statSync`, catching all exceptions raised. This
+  # method calls `fs.statSyncNoException` when provided by the underlying
+  # `fs` module (Electron < 3.0).
+  #
+  # Returns `fs.Stats` if the file exists, `undefined` otherwise.
+  statSyncNoException: (args...) ->
+    statSyncNoException(args...)
+
+  # Public: Calls `fs.lstatSync`, catching all exceptions raised.  This
+  # method calls `fs.lstatSyncNoException` when provided by the underlying
+  # `fs` module (Electron < 3.0).
+  #
+  # Returns `fs.Stats` if the file exists, `undefined` otherwise.
+  lstatSyncNoException: (args...) ->
+    lstatSyncNoException(args...)
+
+# Built-in [l]statSyncNoException methods are only provided in
+# Electron releases before 3.0.
+isElectron3OrHigher =
+  process.versions.electron &&
+  parseInt(process.versions.electron.split('.')[0]) >= 3
+
 statSyncNoException = (args...) ->
-  if fs.statSyncNoException
+  if fs.statSyncNoException and !isElectron3OrHigher
     fs.statSyncNoException(args...)
   else
     try
@@ -562,7 +584,7 @@ statSyncNoException = (args...) ->
       false
 
 lstatSyncNoException = (args...) ->
-  if fs.lstatSyncNoException
+  if fs.lstatSyncNoException and !isElectron3OrHigher
     fs.lstatSyncNoException(args...)
   else
     try


### PR DESCRIPTION
`fs.statSyncNoException` and `fs.lstatSyncNoException` have been [deprecated in Electron 3.0](https://github.com/electron/electron/issues/14451) and might be removed in a future release.  This change updates `fs-plus` to expose wrappers that only use these methods when the `fs` module provides them _and_ we're not  currently running in Electron 3.0 or higher.

### Verification Steps

- [x] Ensure deprecated `fs` method are not used in Electron 3.0 apps
- [x] Ensure `fs` methods are used in Electron 2.0 and lower apps
- [x] Ensure that `fs-plus` implementation is used in plain Node.js apps