### PR TITLE
Fix issues preventing Electron snapshot generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,8 +236,8 @@ Returns `true` if case sensitive, `false` otherwise.
 
 ### `statSyncNoException(path[, options])`
 Calls [`fs.statSync`](https://nodejs.org/docs/latest-v10.x/api/fs.html#fs_fs_statsync_path_options), catching all exceptions raised. This method calls `fs.statSyncNoException` when provided by the underlying `fs` module (Electron < 3.0).
-Returns `fs.Stats` if the file exists, `undefined` otherwise.
+Returns `fs.Stats` if the file exists, `false` otherwise.
 
 ### `lstatSyncNoException(path[, options])`
 Calls [`fs.lstatSync`](https://nodejs.org/docs/latest-v10.x/api/fs.html#fs_fs_lstatsync_path_options), catching all exceptions raised. This method calls `fs.lstatSyncNoException` when provided by the underlying `fs` module (Electron < 3.0).
-Returns `fs.Stats` if the file exists, `undefined` otherwise.
+Returns `fs.Stats` if the file exists, `false` otherwise.

--- a/src/fs-plus.coffee
+++ b/src/fs-plus.coffee
@@ -556,7 +556,7 @@ fsPlus =
   # method calls `fs.statSyncNoException` when provided by the underlying
   # `fs` module (Electron < 3.0).
   #
-  # Returns `fs.Stats` if the file exists, `undefined` otherwise.
+  # Returns `fs.Stats` if the file exists, `false` otherwise.
   statSyncNoException: (args...) ->
     statSyncNoException(args...)
 
@@ -564,18 +564,23 @@ fsPlus =
   # method calls `fs.lstatSyncNoException` when provided by the underlying
   # `fs` module (Electron < 3.0).
   #
-  # Returns `fs.Stats` if the file exists, `undefined` otherwise.
+  # Returns `fs.Stats` if the file exists, `false` otherwise.
   lstatSyncNoException: (args...) ->
     lstatSyncNoException(args...)
 
-# Built-in [l]statSyncNoException methods are only provided in
-# Electron releases before 3.0.
-isElectron3OrHigher =
-  process.versions.electron &&
-  parseInt(process.versions.electron.split('.')[0]) >= 3
+# Built-in [l]statSyncNoException methods are only provided in Electron releases
+# before 3.0.  We delay the version check until first request so that Electron
+# application snapshots can be generated successfully.
+isElectron2OrLower = null
+checkIfElectron2OrLower = ->
+  if isElectron2OrLower == null
+    isElectron2OrLower =
+      process.versions.electron &&
+      parseInt(process.versions.electron.split('.')[0]) <= 2
+  return isElectron2OrLower
 
 statSyncNoException = (args...) ->
-  if fs.statSyncNoException and !isElectron3OrHigher
+  if fs.statSyncNoException and checkIfElectron2OrLower()
     fs.statSyncNoException(args...)
   else
     try
@@ -584,7 +589,7 @@ statSyncNoException = (args...) ->
       false
 
 lstatSyncNoException = (args...) ->
-  if fs.lstatSyncNoException and !isElectron3OrHigher
+  if fs.lstatSyncNoException and checkIfElectron2OrLower()
     fs.lstatSyncNoException(args...)
   else
     try


### PR DESCRIPTION
This change intends to fix an Electron snapshotting issue introduced by #46 where `process.versions.electron` is accessed when the `fs-plus` module is loaded, causing Atom's snapshot verification step to fail with the following error:

```
TypeError: Cannot read property 'electron' of undefined
```

The fix is to delay the evaluation of `process.versions.electron` until the first time `fs.[l]statSyncNoExecption` is called.  I also took this opportunity to clean up the Electron version check logic a bit to make it clearer.

#### Verification Steps

- [x] Use `electron-link` to generate a snapshot script for a simple test script that references `fs-plus` and calls `fs.lstatSyncNoException` **before** this fix, verify that the aforementioned error is raised when loaded into a Chromium VM (see [this example](https://github.com/atom/electron-link/#usage) for an idea of how this is done)
- [x] Repeat the snapshot test with the fixed version of this code, verify that the snapshot script is generated successfully and can be loaded into a Chromium VM

Also verify that the steps in PR #46 still work:

- [ ] Ensure deprecated `fs` method are not used in Electron 3.0 apps
- [ ] Ensure `fs` methods are used in Electron 2.0 and lower apps
- [ ] Ensure that `fs-plus` implementation is used in plain Node.js apps
