### PR TITLE
Include fs-extra methods

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1741,8 +1741,7 @@
     "at-least-node": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-      "dev": true
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
     },
     "atob": {
       "version": "2.1.2",
@@ -2749,7 +2748,6 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
       "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
-      "dev": true,
       "requires": {
         "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
@@ -2877,8 +2875,7 @@
     "graceful-fs": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
-      "dev": true
+      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
     },
     "has-ansi": {
       "version": "2.0.0",
@@ -3271,7 +3268,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
       "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
-      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.6",
         "universalify": "^1.0.0"
@@ -4656,8 +4652,7 @@
     "universalify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-      "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
-      "dev": true
+      "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug=="
     },
     "unset-value": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "async": "^1.5.2",
+    "fs-extra": "^9.0.1",
     "mkdirp": "^0.5.1",
     "rimraf": "^2.5.2",
     "underscore-plus": "1.x"

--- a/src/fs-plus.mjs
+++ b/src/fs-plus.mjs
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import fsExtra from 'fs-extra';
 import Module from 'module';
 import path from 'path';
 
@@ -829,6 +830,8 @@ module.exports = new Proxy({}, {
   get(target, key) {
     if (fsPlus.hasOwnProperty(key)) {
       return fsPlus[key];
+    } else if (fsExtra.hasOwnProperty(key)) {
+      return fsExtra[key];
     } else {
       return fs[key];
     }


### PR DESCRIPTION
### Description of the change

This adds fs-extra methods. They will be considered "after" fs-plus methods so it will not have any conflict or breakage.

### Future Improvements

Currently, there are a few methods that are used in both packages. Technically, we do not need to use mkdirp, rimraf, etc anymore since fs-extra supports all of these (with a more up to date implementation). Some other methods from the fs-plus are not using the native `fs` functions which means they do not support all types of inputs such as [Buffer or URL](https://nodejs.org/api/fs.html#fs_fs_copyfilesync_src_dest_mode). In future PRs, I will write a few type-dispatch sentences to decide between the native implementation and fs-plus implementation. This allows keeping the methods of fs-plus that offer anything interesting over the native fs functions.
```
copyFileSync
existsSync
writeFile
writeFileSync
copySync
copy
moveSync
move
remove
removeSync
```

So, this PR paves the way for future PRs. 🚀 

### Benefits

fs-extra has many good methods which we can use. We will not need to install two separate fs library anymore!


### Verification

All the tests pass.